### PR TITLE
Bump up Jedis version to 2.6.2

### DIFF
--- a/external/storm-redis/pom.xml
+++ b/external/storm-redis/pom.xml
@@ -41,7 +41,7 @@
     </developers>
 
     <properties>
-        <jedis.version>2.6.1</jedis.version>
+        <jedis.version>2.6.2</jedis.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Since Jedis has a new release 2.6.2 at the last day of 2014 (or first day of 2015 regarding timezone), seems like we can apply it.

https://github.com/xetorthio/jedis/releases/tag/jedis-2.6.2